### PR TITLE
Fix the capitalization of Autolab on various pages

### DIFF
--- a/templates/hw/ao1.html
+++ b/templates/hw/ao1.html
@@ -105,7 +105,7 @@
                     only call methods provided in the Calculator class. You may add more methods/variables/classes/etc,
                     but do
                     not access them from your tests since they will not exist in my correct/incorrect solutions on
-                    AutoLab.
+                    Autolab.
                 </p>
 
                 <hr/>
@@ -127,7 +127,7 @@
                 <p>
                     Test the following features of your calculator.model.Calculator class. In your tests, only call the
                     methods that are provided in the handout code as any other methods.variables.classes won't exist
-                    in the correct/incorrect solutions and will cause errors in AutoLab. You will call the various
+                    in the correct/incorrect solutions and will cause errors in Autolab. You will call the various
                     "pressed" methods to simulate pressing buttons on the calculator, then call displayNumber and
                     assert that it returns the expected value.
                 </p>
@@ -241,7 +241,7 @@
                 </h5>
                 <p>
                     To limit the complexity of this assignment there are certain sequences of button presses that have
-                    undefined behaviour. These sequences will not be tested in AutoLab and you must not test these
+                    undefined behaviour. These sequences will not be tested in Autolab and you must not test these
                     sequences
                     in your tests since the expected number to be displayed is undefined. Do not test any of the
                     following:

--- a/templates/hw/task1.html
+++ b/templates/hw/task1.html
@@ -57,7 +57,7 @@
                 </p>
                 <p>
                     To submit your project, create a zip file containing your entire project and
-                    submit it to AutoLab. (Click file -> export -> Project to Zip File, though there may be
+                    submit it to Autolab. (Click file -> export -> Project to Zip File, though there may be
                     slight differences to this across OSes and versions)
                 </p>
 
@@ -70,7 +70,7 @@
 
                 <hr/>
                 <p>
-                    This is primarily a testing task and your feedback in AutoLab will begin by checking your tests.
+                    This is primarily a testing task and your feedback in Autolab will begin by checking your tests.
                     You will write tests for 3 different methods. All of your testing will be in the
                     tests.TestProblemSet class. You are strongly encouraged to write many individual tests in this one
                     class.
@@ -174,11 +174,11 @@
                 <br/>
                 <hr/>
 
-                <h3>AutoLab Feedback</h3>
+                <h3>Autolab Feedback</h3>
 
                 <hr/>
                 <p>
-                    The feedback in AutoLab will be given in 3 phases. If you don't complete a phase, then feedback for
+                    The feedback in Autolab will be given in 3 phases. If you don't complete a phase, then feedback for
                     the following phase(s) will not be given.
                 </p>
 
@@ -206,7 +206,7 @@
                             </li>
                             <li>
                                 Passing this phase does not necessarily mean that your testing is completely thorough.
-                                Satisfying AutoLab is the bare minimum testing requirement. The incorrect solutions will
+                                Satisfying Autolab is the bare minimum testing requirement. The incorrect solutions will
                                 not cover every possible mistake, and it is sometimes possible to pass this phase
                                 with very weak testing. If you are struggling to earn credit for code that you believe
                                 is correct, you should write more than the required tests
@@ -216,7 +216,7 @@
                     <li>Running my tests on Your Solution
                         <ul>
                             <li>
-                                Once AutoLab is happy with your tests, it will run my tests against your code to check
+                                Once Autolab is happy with your tests, it will run my tests against your code to check
                                 it for correctness. If your testing is thorough, and your code passes your tests, then
                                 you should pass this phase. If you pass your tests, but fail one of mine, it is an
                                 indicator that you should write more tests to help expose your bug
@@ -226,7 +226,7 @@
                 </ol>
 
                 <p>
-                    Once you complete all 3 phases, you will have completed this Task and AutoLab will confirm this
+                    Once you complete all 3 phases, you will have completed this Task and Autolab will confirm this
                     with a score of 1.0 for complete.
                 </p>
                 <hr/>

--- a/templates/hw/task2.html
+++ b/templates/hw/task2.html
@@ -164,11 +164,11 @@
                 <br/>
                 <hr/>
 
-                <h3>AutoLab Feedback</h3>
+                <h3>Autolab Feedback</h3>
 
                 <hr/>
                 <p>
-                    The feedback in AutoLab will be given in 3 phases. If you don't complete a phase, then feedback for
+                    The feedback in Autolab will be given in 3 phases. If you don't complete a phase, then feedback for
                     the following phase(s) will not be given.
                 </p>
 
@@ -185,7 +185,7 @@
                 </ol>
 
                 <p>
-                    Once you complete all 3 phases, you will have completed this Task and AutoLab will confirm this
+                    Once you complete all 3 phases, you will have completed this Task and Autolab will confirm this
                     with a score of 1.0 for complete.
                 </p>
                 <hr/>

--- a/templates/hw/task3.html
+++ b/templates/hw/task3.html
@@ -162,11 +162,11 @@
                 <br/>
                 <hr/>
 
-                <h3>AutoLab Feedback</h3>
+                <h3>Autolab Feedback</h3>
 
                 <hr/>
                 <p>
-                    The feedback in AutoLab will be given in 3 phases. If you don't complete a phase, then feedback for
+                    The feedback in Autolab will be given in 3 phases. If you don't complete a phase, then feedback for
                     the following phase(s) will not be given.
                 </p>
 
@@ -183,7 +183,7 @@
                 </ol>
 
                 <p>
-                    Once you complete all 3 phases, you will have completed this Task and AutoLab will confirm this
+                    Once you complete all 3 phases, you will have completed this Task and Autolab will confirm this
                     with a score of 1.0 for complete.
                 </p>
                 <hr/>

--- a/templates/hw/task4.html
+++ b/templates/hw/task4.html
@@ -266,7 +266,7 @@
 
                 <p>
                     Finally, implement the following classes/methods for which you did not write tests. These classes will be
-                    tested in AutoLab, but you are not expected to have tests of your own for these classes.
+                    tested in Autolab, but you are not expected to have tests of your own for these classes.
                 </p>
                 <ul>
                     <li>ratings.datastructures.Comparator - This class has been provided in the handout code
@@ -336,11 +336,11 @@
                 <br/>
                 <hr/>
 
-                <h3>AutoLab Feedback</h3>
+                <h3>Autolab Feedback</h3>
 
                 <hr/>
                 <p>
-                    The feedback in AutoLab will be given in 3 phases. If you don't complete a phase, then feedback for
+                    The feedback in Autolab will be given in 3 phases. If you don't complete a phase, then feedback for
                     the following phase(s) will not be given.
                 </p>
 
@@ -357,7 +357,7 @@
                 </ol>
 
                 <p>
-                    Once you complete all 3 phases, you will have completed this Task and AutoLab will confirm this
+                    Once you complete all 3 phases, you will have completed this Task and Autolab will confirm this
                     with a score of 1.0 for complete.
                 </p>
                 <hr/>

--- a/templates/hw/task5.html
+++ b/templates/hw/task5.html
@@ -127,7 +127,7 @@
 
 
                 <ul>
-                    <li>The BinaryTreeNode has been provided in the handout repo. An object of this type will be returned by one of your methods and will be tested in AutoLab.
+                    <li>The BinaryTreeNode has been provided in the handout repo. An object of this type will be returned by one of your methods and will be tested in Autolab.
                     All these methods must exist and be named exactly as they are in the repo or there will be errors during
                         grading</li>
                 </ul>
@@ -213,11 +213,11 @@
                 <br/>
                 <hr/>
 
-                <h3>AutoLab Feedback</h3>
+                <h3>Autolab Feedback</h3>
 
                 <hr/>
                 <p>
-                    The feedback in AutoLab will be given in 3 phases. If you don't complete a phase, then feedback for
+                    The feedback in Autolab will be given in 3 phases. If you don't complete a phase, then feedback for
                     the following phase(s) will not be given.
                 </p>
 
@@ -234,7 +234,7 @@
                 </ol>
 
                 <p>
-                    Once you complete all 3 phases, you will have completed this Task and AutoLab will confirm this
+                    Once you complete all 3 phases, you will have completed this Task and Autolab will confirm this
                     with a score of 1.0 for complete.
                 </p>
                 <hr/>

--- a/templates/hw/task6.html
+++ b/templates/hw/task6.html
@@ -185,11 +185,11 @@
                 <br/>
                 <hr/>
 
-                <h3>AutoLab Feedback</h3>
+                <h3>Autolab Feedback</h3>
 
                 <hr/>
                 <p>
-                    The feedback in AutoLab will be given in 3 phases. If you don't complete a phase, then feedback for
+                    The feedback in Autolab will be given in 3 phases. If you don't complete a phase, then feedback for
                     the following phase(s) will not be given.
                 </p>
 
@@ -206,7 +206,7 @@
                 </ol>
 
                 <p>
-                    Once you complete all 3 phases, you will have completed this Task and AutoLab will confirm this
+                    Once you complete all 3 phases, you will have completed this Task and Autolab will confirm this
                     with a score of 1.0 for complete.
                 </p>
                 <hr/>

--- a/templates/hw/task7.html
+++ b/templates/hw/task7.html
@@ -212,11 +212,11 @@
                 <br/>
                 <hr/>
 
-                <h3>AutoLab Feedback</h3>
+                <h3>Autolab Feedback</h3>
 
                 <hr/>
                 <p>
-                    The feedback in AutoLab will be given in 3 phases. If you don't complete a phase, then feedback for
+                    The feedback in Autolab will be given in 3 phases. If you don't complete a phase, then feedback for
                     the following phase(s) will not be given.
                 </p>
 
@@ -233,7 +233,7 @@
                 </ol>
 
                 <p>
-                    Once you complete all 3 phases, you will have completed this Task and AutoLab will confirm this
+                    Once you complete all 3 phases, you will have completed this Task and Autolab will confirm this
                     with a score of 1.0 for complete.
                 </p>
                 <hr/>

--- a/templates/hw/task8.html
+++ b/templates/hw/task8.html
@@ -123,11 +123,11 @@
                 <br/>
                 <hr/>
 
-                <h3>AutoLab Feedback</h3>
+                <h3>Autolab Feedback</h3>
 
                 <hr/>
                 <p>
-                    The feedback in AutoLab will be given in 3 phases. If you don't complete a phase, then feedback for
+                    The feedback in Autolab will be given in 3 phases. If you don't complete a phase, then feedback for
                     the following phase(s) will not be given.
                 </p>
 
@@ -144,7 +144,7 @@
                 </ol>
 
                 <p>
-                    Once you complete all 3 phases, you will have completed this Task and AutoLab will confirm this
+                    Once you complete all 3 phases, you will have completed this Task and Autolab will confirm this
                     with a score of 1.0 for complete.
                 </p>
                 <hr/>


### PR DESCRIPTION
Replace "AutoLab" with "Autolab"